### PR TITLE
Add initial database migrations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,4 @@ services:
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
   - echo "DATABASE_URL='postgres://localhost/travis_ci_test'" > .env.test
-  - bundle exec rake db:create
   - bundle exec rake db:migrate

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,9 @@
 language: ruby
+services:
+  - postgresql
+
+before_script:
+  - psql -c 'create database travis_ci_test;' -U postgres
+  - echo "DATABASE_URL='postgres://localhost/travis_ci_test'" > .env.test
+  - bundle exec rake db:create
+  - bundle exec rake db:migrate

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ services:
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
   - echo "DATABASE_URL='postgres://localhost/travis_ci_test'" > .env.test
+  - echo "SESSION_SECRET='8dab59a91eab93b3675f787cca843527'" >> .env.test
   - bundle exec rake db:migrate

--- a/Gemfile
+++ b/Gemfile
@@ -33,10 +33,13 @@ group :development, :test do
 end
 
 group :test do
-  gem "capybara"
-  gem "capybara-screenshot"
+  #gem "capybara"
+  #gem "capybara-screenshot"
   gem "database_cleaner"
-  gem "poltergeist"
+  #gem "poltergeist"
   gem "rspec"
   gem "rom-factory", "~> 0.5"
+  gem "rack-test"
+  #gem "minitest"
+  #gem "minitest-hooks"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
     byebug (9.1.0)
-    capybara (2.16.1)
-      addressable
-      mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (~> 2.0)
-    capybara-screenshot (1.0.18)
-      capybara (>= 1.0, < 3)
-      launchy
-    cliver (0.3.2)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
@@ -98,25 +85,14 @@ GEM
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     inflecto (0.0.2)
-    launchy (2.4.3)
-      addressable (~> 2.3)
     method_source (0.9.0)
-    mini_mime (1.0.0)
-    mini_portile2 (2.3.0)
-    nokogiri (1.8.1)
-      mini_portile2 (~> 2.3.0)
     pg (0.21.0)
-    poltergeist (1.16.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     pry-byebug (3.5.0)
       byebug (~> 9.1)
       pry (~> 0.10)
-    public_suffix (3.0.1)
     puma (3.11.0)
     rack (2.0.3)
     rack-protection (2.0.0)
@@ -197,19 +173,12 @@ GEM
     thor (0.20.0)
     tilt (2.0.8)
     transproc (1.0.2)
-    websocket-driver (0.7.0)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.3)
     wisper (2.0.0)
-    xpath (2.1.0)
-      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  capybara
-  capybara-screenshot
   database_cleaner
   dry-matcher (~> 0.6.0)
   dry-monads (~> 0.3)
@@ -222,10 +191,10 @@ DEPENDENCIES
   dry-web (~> 0.7)
   dry-web-roda (~> 0.7)
   pg
-  poltergeist
   pry-byebug
   puma
   rack (>= 2.0)
+  rack-test
   rack_csrf
   rake
   rom (~> 4.0)

--- a/apps/main/lib/dms/main/donation_repo.rb
+++ b/apps/main/lib/dms/main/donation_repo.rb
@@ -1,0 +1,61 @@
+require "dms/repository"
+module Dms
+  module Main
+    class DonationRepo < Dms::Repository[:donations]
+      def create_with_donor(donation)
+        saved_donation = donations.transaction do
+          new_donation = donations.changeset(
+            :create, donation_attrs(donation.fetch(:donation))
+          ).associate(find_or_create_donor(donation))
+
+          new_donation.commit
+        end
+        Dms::Main::Entities::Donation::WithDonor.new(
+          aggregate(:donor).by_pk(saved_donation.id).one
+        )
+      end
+
+      def donation_attrs(attrs)
+        {
+          amount: attrs.fetch(:amount),
+          currency: attrs.fetch(:currency),
+          start_date: attrs.fetch(:startDate),
+          end_date: attrs.fetch(:endDate),
+          donation_type: 1, # TODO: lookup donation type
+          zakat: attrs.fetch(:zakat)
+        }
+      end
+
+      def donor_attrs(attrs)
+        {
+          email: attrs.fetch(:email),
+          first_name: attrs.fetch(:firstName),
+          last_name: attrs.fetch(:lastName)
+        }
+      end
+
+      def query(conditions)
+        donations.where(conditions)
+      end
+
+      def by_id(id)
+        donations.by_pk(id).one!
+      end
+
+      private
+      # TODO Move to donor repo
+      def find_or_create_donor(donation)
+        donor = find_donor_with_email(donation.dig(:donor, :email))
+        donor || create_donor_from_donation(donation)
+      end
+
+      def find_donor_with_email(email)
+        donors.where(email: email).one
+      end
+
+      def create_donor_from_donation(donation)
+        donors.changeset(:create, donor_attrs(donation.fetch(:donor))).commit
+      end
+    end
+  end
+end

--- a/apps/main/lib/dms/main/donations/operations/create.rb
+++ b/apps/main/lib/dms/main/donations/operations/create.rb
@@ -1,24 +1,22 @@
+require "dms/main/import"
 require "dms/main/entities/donation"
 require "dms/main/donations/validations/donation"
+require "dms/matcher"
 
-require 'dry-monads'
-require "dry/matcher"
-require "dry/matcher/either_matcher"
 module Dms
   module Main
     module Donations
       module Operations
         class Create
-          include Dry::Matcher.for(:call, with: Dry::Matcher::EitherMatcher)
+          include Dms::Matcher
+          include Dms::Main::Import["donation_repo"]
 
           def call(attributes)
-            # Validation
             validation = Validations::DonationSchema.(attributes)
             if validation.success?
-              puts "PASSED VALIDATION"
-              Dry::Monads::Right(validation)
+              donation = donation_repo.create_with_donor(validation.output)
+              Dry::Monads::Right(donation)
             else
-              puts "FAILED VALIDATION"
               Dry::Monads::Left(validation)
             end
           end

--- a/apps/main/lib/dms/main/entities/donation.rb
+++ b/apps/main/lib/dms/main/entities/donation.rb
@@ -7,14 +7,13 @@ module Dms
   module Main
     module Entities
       class Donation < Dry::Struct
-
+        constructor_type :schema
         Donation_Types = Types::Strict::String.enum('one-off', 'monthly', 'yearly')
 
         attribute :id, Types::Strict::Int
-        attribute :amount_in_pence, Types::Strict::Int
+        attribute :amount, Types::Strict::Int
         attribute :currency, Types::Strict::String
         attribute :zakat, Types::Bool
-        attribute :admin_fee_contribution_in_pence, Types::Strict::Int
         attribute :start_date, Types::Strict::Time
         attribute :end_date, Types::Strict::Time
         attribute :created_at, Types::Strict::Time
@@ -23,6 +22,32 @@ module Dms
 
         class WithDonor < Donation
           attribute :donor, Entities::Person
+
+          def to_json_api
+            {
+              'data' => {
+                'id' => id,
+                'type' => 'donations',
+                'attributes' => {
+                  'amount' => amount,
+                  'currency' => currency,
+                  'zakat' => zakat,
+                  'start_date' => start_date,
+                  'end_date' => end_date,
+                  'donation_type' => donation_type
+                },
+                'relationships' => {
+                  'donor' => {
+                    'links' => {
+                      "self" => "http://example.com/donations/#{id}/relationships/donor",
+                      "related" => "http://example.com/donations/#{id}/donor"
+                    },
+                    'data' => { 'type' => 'people', 'id' => donor.id }
+                  }
+                }
+              }
+            }.to_json
+          end
         end
 
         class WithDonorAndCause < Donation

--- a/apps/main/lib/dms/main/entities/person.rb
+++ b/apps/main/lib/dms/main/entities/person.rb
@@ -4,6 +4,8 @@ module Dms
   module Main
     module Entities
       class Person < Dry::Struct
+        constructor_type :schema
+        attribute :id, Types::Strict::Int
         attribute :email, Types::Strict::String
         attribute :title, Types::Strict::String
         attribute :first_name, Types::Strict::String

--- a/apps/main/web/routes/donation.rb
+++ b/apps/main/web/routes/donation.rb
@@ -7,11 +7,11 @@ module Dms
             create.(r["data"]) do |m|
               m.success do |created_donation|
                 response.status = 202 # Accepted and added to sidekick
-                created_donation.to_json
+                created_donation.to_json_api
               end
               m.failure do |validation|
                 response.status = 400 # Malformed request
-                validation.errors.to_json
+                validation.errors.to_hash.to_json
               end
             end
           end

--- a/db/migrate/20171202191300_create_donations.rb
+++ b/db/migrate/20171202191300_create_donations.rb
@@ -1,0 +1,14 @@
+ROM::SQL.migration do
+  change do
+    create_table :donations do
+      primary_key :id
+      column :donor_id, :int, null: false, index: true
+      column :amount, :int, null:false
+      column :currency, :text, null: false
+      column :donation_type, :int, null: false, index: true
+      column :zakat, :boolean, default: false, index: true
+      column :created_at, :timestamp, null: false, default: Sequel.lit("(now() at time zone 'utc')")
+      column :updated_at, :timestamp, null: false, default: Sequel.lit("(now() at time zone 'utc')")
+    end
+  end
+end

--- a/db/migrate/20171202193355_create_donors.rb
+++ b/db/migrate/20171202193355_create_donors.rb
@@ -1,0 +1,12 @@
+ROM::SQL.migration do
+  change do
+    create_table :donors do
+      primary_key :id
+      column :email, :text, null: false, index: true
+      column :first_name, :text, null: false
+      column :last_name, :text, null: false
+      column :created_at, :timestamp, null: false, default: Sequel.lit("(now() at time zone 'utc')")
+      column :updated_at, :timestamp, null: false, default: Sequel.lit("(now() at time zone 'utc')")
+    end
+  end
+end

--- a/db/migrate/20171202194414_create_causes.rb
+++ b/db/migrate/20171202194414_create_causes.rb
@@ -1,0 +1,12 @@
+ROM::SQL.migration do
+  change do
+    create_table :causes do
+      primary_key :id
+      column :name, :text, null: false, index:true
+      column :code, :text, null: false, index:true
+      column :description, :text
+      column :created_at, :timestamp, null: false, default: Sequel.lit("(now() at time zone 'utc')")
+      column :updated_at, :timestamp, null: false, default: Sequel.lit("(now() at time zone 'utc')")
+    end
+  end
+end

--- a/db/migrate/20171202194420_create_projects.rb
+++ b/db/migrate/20171202194420_create_projects.rb
@@ -1,0 +1,12 @@
+ROM::SQL.migration do
+  change do
+    create_table :projects do
+      primary_key :id
+      column :active, :boolean, default: true, index: true
+      column :name, :text, null: false, index:true
+      column :description, :text
+      column :code, :text, null: false, index:true
+      column :cause_id, :integer, null: false, index:true
+    end
+  end
+end

--- a/lib/dms/matcher.rb
+++ b/lib/dms/matcher.rb
@@ -1,0 +1,7 @@
+require "dry/monads"
+require "dry/matcher"
+require "dry/matcher/either_matcher"
+
+module Dms
+  Matcher = Dry::Matcher.for(:call, with: Dry::Matcher::EitherMatcher)
+end

--- a/lib/persistence/relations/donations.rb
+++ b/lib/persistence/relations/donations.rb
@@ -1,0 +1,11 @@
+module Persistence
+  module Relations
+    class Donations < ROM::Relation[:sql]
+      schema(:donations, infer: true) do
+        associations do
+          belongs_to :donor
+        end
+      end
+    end
+  end
+end

--- a/lib/persistence/relations/donors.rb
+++ b/lib/persistence/relations/donors.rb
@@ -1,0 +1,11 @@
+module Persistence
+  module Relations
+    class Donors < ROM::Relation[:sql]
+      schema(:donors, infer: true) do
+        associations do
+          has_many :donations
+        end
+      end
+    end
+  end
+end

--- a/spec/db_spec_helper.rb
+++ b/spec/db_spec_helper.rb
@@ -1,23 +1,16 @@
-require_relative "spec_helper"
-
-Dms::Container.start :persistence
-
-Dir[SPEC_ROOT.join("support/db/*.rb").to_s].each(&method(:require))
-Dir[SPEC_ROOT.join("shared/db/*.rb").to_s].each(&method(:require))
-
 require "database_cleaner"
+require_relative "test_helper"
+require_relative "support/db/helpers"
+
 DatabaseCleaner[:sequel, connection: Test::DatabaseHelpers.db].strategy = :truncation
 
-RSpec.configure do |config|
-  config.include Test::DatabaseHelpers
-
-  config.before :suite do
-    DatabaseCleaner.clean_with :truncation
+class Minitest::Spec
+  include Rack::Test::Methods
+  before :all do
+    DatabaseCleaner.start
   end
 
-  config.around :each do |example|
-    DatabaseCleaner.cleaning do
-      example.run
-    end
+  after :each do
+    DatabaseCleaner.clean
   end
 end

--- a/spec/factories/example.rb
+++ b/spec/factories/example.rb
@@ -1,9 +1,0 @@
-# Define your factories here, e.g.
-#
-# Factory.define :article do |f|
-#   f.sequence(:slug) { |i| "article-#{i}" }
-#   f.title { fake(:lorem, :words, 5) }
-#   f.body { fake(:lorem, :paragraphs, 1) }
-# end
-#
-# See https://github.com/rom-rb/rom-factory for more.

--- a/spec/main/lib/dms/main/web/create_donation_spec.rb
+++ b/spec/main/lib/dms/main/web/create_donation_spec.rb
@@ -1,0 +1,116 @@
+require 'spec_helper'
+
+RSpec.describe Dms::Web do
+  let(:valid_json) do
+    {
+      'data' => {
+        'donation' => {
+          'amount' => 20.00,
+          'currency' => 'GBP',
+          'startDate' => '12/12/2009',
+          'endDate' => '12/12/2019',
+          'donationType' => 'one-off',
+          'zakat' => 'no'
+        },
+        'cause' => {
+          'project' => 'SUDAN',
+          'causeCode' => 'FOOD'
+        },
+        'donor' => {
+          'email' => 'hamza@khan-cheema.com',
+          'firstName' => 'Hamza',
+          'lastName' => 'Khan'
+        }
+      }
+    }.to_json
+  end
+
+  let(:expected_json_api_response) do
+    {
+      'data' => {
+        'id' => parsed_donation_id,
+        'type' => 'donations',
+        'attributes' => {
+          'amount' => 20,
+          'currency' => 'GBP',
+          'zakat' => false,
+          'start_date' => nil,
+          'end_date' => nil,
+          'donation_type' => 'monthly'
+        },
+        'relationships' => {
+          'donor' => {
+            'links' => {
+              "self" => "http://example.com/donations/#{parsed_donation_id}/relationships/donor",
+              "related" => "http://example.com/donations/#{parsed_donation_id}/donor"
+            },
+            'data' => { 'type' => 'people', 'id' => parsed_donor_id }
+          }
+        }
+      }
+    }
+  end
+
+  context 'with valid input' do
+    before do
+      post_with_json('/donations', valid_json)
+    end
+
+    it 'returns a successful response' do
+      expect last_response.ok?
+    end
+
+    it 'returns a 202 http status' do
+      expect last_response.status == 202
+    end
+
+    it 'returns expected json-api response' do
+      expect(parsed_response).to eq expected_json_api_response
+    end
+
+    it 'creates donation' do
+      expect(parsed_donation_id).to_not be_nil
+    end
+
+    it 'creates donor' do
+      expect(parsed_donor_id).to_not be_nil
+    end
+  end
+
+  context "when invalid" do
+    let(:invalid_json) do
+      {
+        'data' => {}
+      }.to_json
+    end
+
+    before do
+      post_with_json('/donations', invalid_json)
+    end
+
+    it 'errors on donation and donor fields' do
+      expect(parsed_response.fetch('donation')).to include('is missing')
+      expect(parsed_response.fetch('donor')).to include('is missing')
+    end
+
+    it 'returns a 400' do
+      expect last_response.status == 400
+    end
+  end
+
+  def parsed_response
+    JSON.parse(last_response.body)
+  end
+
+  def parsed_donation_id
+    parsed_response.dig('data', 'id')
+  end
+
+  def parsed_donor_id
+    parsed_response.dig('data', 'relationships', 'donor', 'data', 'id')
+  end
+
+  def post_with_json(uri, json)
+    post(uri, json, 'CONTENT_TYPE' => 'application/json')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,61 +1,54 @@
-ENV["RACK_ENV"] = "test"
-
-require "pry-byebug"
+ENV['RACK_ENV'] = 'test'
+require 'rack/test'
+require 'pry-byebug'
 
 SPEC_ROOT = Pathname(__FILE__).dirname
 
-Dir[SPEC_ROOT.join("support/*.rb").to_s].each(&method(:require))
-Dir[SPEC_ROOT.join("shared/*.rb").to_s].each(&method(:require))
+require_relative SPEC_ROOT.join('../system/dms/container')
+require 'database_cleaner'
 
-require SPEC_ROOT.join("../system/dms/container")
+require_relative SPEC_ROOT.join("../system/dms/web")
+require_relative SPEC_ROOT.join("../apps/main/system/dms/main/web")
+require_relative "support/web/helpers"
+require_relative "support/db/helpers"
+
+require "database_cleaner"
+DatabaseCleaner[:sequel, connection: Test::DatabaseHelpers.db].strategy = :truncation
 
 RSpec.configure do |config|
   config.disable_monkey_patching!
+  config.include Rack::Test::Methods
+  config.include Test::WebHelpers
 
   config.expect_with :rspec do |expectations|
-    # This option will default to `true` in RSpec 4.
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
 
   config.mock_with :rspec do |mocks|
-    # Prevents you from mocking or stubbing a method that does not exist on a
-    # real object. This is generally recommended, and will default to `true`
-    # in RSpec 4.
     mocks.verify_partial_doubles = true
   end
 
-  # These two settings work together to allow you to limit a spec run to
-  # individual examples or groups you care about by tagging them with `:focus`
-  # metadata. When nothing is tagged with `:focus`, all examples get run.
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
 
-  # Allows RSpec to persist some state between runs in order to support the
-  # `--only-failures` and `--next-failure` CLI options.
   config.example_status_persistence_file_path = "spec/examples.txt"
 
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
   if config.files_to_run.one?
-    # Use the documentation formatter for detailed output, unless a formatter
-    # has already been configured (e.g. via a command-line flag).
     config.default_formatter = "doc"
   end
 
-  # Print the 10 slowest examples and example groups at the end of the spec
-  # run, to help surface which specs are running particularly slow.
   config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
   config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
   Kernel.srand config.seed
+
+  config.before :suite do
+    DatabaseCleaner.clean_with :truncation
+    Test::WebHelpers.app.freeze
+  end
+
+  config.around :each do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
 end

--- a/spec/web_spec_helper.rb
+++ b/spec/web_spec_helper.rb
@@ -1,37 +1,28 @@
-require_relative "db_spec_helper"
+require_relative 'spec_helper'
+require 'database_cleaner'
 
-require "rack/test"
-require "capybara/rspec"
-require "capybara-screenshot/rspec"
-require "capybara/poltergeist"
+require_relative SPEC_ROOT.join("../system/dms/web")
+require_relative SPEC_ROOT.join("../apps/main/system/dms/main/web")
+require_relative "support/web/helpers"
+require_relative "support/db/helpers"
 
 Dir[SPEC_ROOT.join("support/web/*.rb").to_s].each(&method(:require))
-Dir[SPEC_ROOT.join("shared/web/*.rb").to_s].each(&method(:require))
 
-require SPEC_ROOT.join("../system/boot").realpath
+# TODO: Move into db_spec_helper
+require "database_cleaner"
+DatabaseCleaner[:sequel, connection: Test::DatabaseHelpers.db].strategy = :truncation
 
-Capybara.app = Test::WebHelpers.app
-Capybara.server_port = 3001
-Capybara.save_path = "#{File.dirname(__FILE__)}/../tmp/capybara-screenshot"
-Capybara.javascript_driver = :poltergeist
-Capybara::Screenshot.prune_strategy = {keep: 10}
-
-Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(
-    app,
-    js_errors: false,
-    phantomjs_logger: File.open(SPEC_ROOT.join("../log/phantomjs.log"), "w"),
-    phantomjs_options: %w(--load-images=no),
-    window_size: [1600, 768],
-  )
-end
-
-RSpec.configure do |config|
-  config.include Rack::Test::Methods, type: :request
-  config.include Rack::Test::Methods, Capybara::DSL, type: :feature
-  config.include Test::WebHelpers
-
-  config.before :suite do
+# Use the minitest-hooks plugin to add the :all condition
+# To run code before any specs in the suite are executed
+class Minitest::Spec
+  before :all do
+    include Rack::Test::Methods
+    include Test::WebHelpers
     Test::WebHelpers.app.freeze
+    DatabaseCleaner.start
+  end
+
+  after :each do
+    DatabaseCleaner.clean
   end
 end


### PR DESCRIPTION
#2 A big commit that allows donations to be created alongside donors. I am keeping
the database interaction in one repo at the moment, but the donor code can be
moved to its own repo if needed.

One integration spec has been written that tests the submission of donation to
the API.

Initially it has been decided to use the JSON-API format.